### PR TITLE
[REF] Convert train script into a function

### DIFF
--- a/example/train.py
+++ b/example/train.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 """Train a simple CNN on MNIST using checkpoints, integrated with Weights & Biases.
 
 The changes required to integrate checkpointing with wandb are tagged with 'NOTE'.

--- a/example/train.py
+++ b/example/train.py
@@ -18,7 +18,6 @@ from torchvision.transforms import ToTensor
 
 from wandb_preempt.checkpointer import Checkpointer, get_resume_value
 
-
 LOGGING_INTERVAL = 50  # Num batches between logging to stdout and wandb
 VERBOSE = True  # Enable verbose output
 

--- a/example/train.py
+++ b/example/train.py
@@ -150,13 +150,8 @@ def main(args):
     checkpointer.remove_checkpoints()
 
 
-def cli(arg_list=None):
-    r"""Command-line interface for model training."""
-    parser = get_parser()
-    args = parser.parse_args(arg_list)
-    main(args)
-
-
 if __name__ == "__main__":
     # Run as a script
-    cli()
+    parser = get_parser()
+    args = parser.parse_args()
+    main(args)

--- a/example/train.py
+++ b/example/train.py
@@ -30,7 +30,7 @@ def get_parser():
         "--lr", type=float, default=0.01, help="Learning rate. Default: %(default)s"
     )
     parser.add_argument(
-        "--max_epochs", type=int, default=10, help="Num epochs. Default: %(default)s"
+        "--epochs", type=int, default=10, help="Number of epochs. Default: %(default)s"
     )
     parser.add_argument(
         "--batch_size", type=int, default=256, help="Batch size. Default: %(default)s"
@@ -65,7 +65,7 @@ def main(args):
     loss_func = CrossEntropyLoss().to(DEV)
     print(f"Using SGD with learning rate {args.lr}.")
     optimizer = SGD(model.parameters(), lr=args.lr)
-    lr_scheduler = CosineAnnealingLR(optimizer, T_max=args.max_epochs)
+    lr_scheduler = CosineAnnealingLR(optimizer, T_max=args.epochs)
     scaler = GradScaler()
 
     # NOTE: Set up a check-pointer which will load and save checkpoints.
@@ -86,7 +86,7 @@ def main(args):
     start_epoch = checkpointer.load_latest_checkpoint()
 
     # training
-    for epoch in range(start_epoch, args.max_epochs):
+    for epoch in range(start_epoch, args.epochs):
         model.train()
         for step, (inputs, target) in enumerate(train_loader):
             optimizer.zero_grad()

--- a/example/train.py
+++ b/example/train.py
@@ -17,100 +17,121 @@ from torchvision.transforms import ToTensor
 
 from wandb_preempt.checkpointer import Checkpointer, get_resume_value
 
-parser = ArgumentParser("Train a simple CNN on MNIST using SGD.")
-parser.add_argument("--lr", type=float, default=0.01, help="SGD's learning rate.")
-parser.add_argument(
-    "--max_epochs",
-    type=int,
-    default=10,
-    help="Number of epochs to train for.",
-)
-args = parser.parse_args()
 
 LOGGING_INTERVAL = 50  # print and log loss at this frequency
 BATCH_SIZE = 256
 VERBOSE = True
-
-manual_seed(0)  # make deterministic
-DEV = device("cuda" if cuda.is_available() else "cpu")
-
 # NOTE: Define the directory where checkpoints are stored
 SAVEDIR = "checkpoints"
 
-# NOTE: Figure out the `resume` value and pass it to wandb
-run = wandb.init(resume=get_resume_value(verbose=VERBOSE))
 
-# Set up the data, neural net, loss function, and optimizer
-train_dataset = MNIST("./data", train=True, download=True, transform=ToTensor())
-train_loader = DataLoader(dataset=train_dataset, batch_size=BATCH_SIZE, shuffle=True)
-model = Sequential(
-    Conv2d(1, 3, kernel_size=5, stride=2),
-    ReLU(),
-    Flatten(),
-    Linear(432, 50),
-    ReLU(),
-    Linear(50, 10),
-).to(DEV)
-loss_func = CrossEntropyLoss().to(DEV)
-print(f"Using SGD with learning rate {args.lr}.")
-optimizer = SGD(model.parameters(), lr=args.lr)
-lr_scheduler = CosineAnnealingLR(optimizer, T_max=args.max_epochs)
-scaler = GradScaler()
+def get_parser():
+    r"""Create argument parser."""
+    parser = ArgumentParser("Train a simple CNN on MNIST using SGD.")
+    parser.add_argument("--lr", type=float, default=0.01, help="SGD's learning rate.")
+    parser.add_argument(
+        "--max_epochs",
+        type=int,
+        default=10,
+        help="Number of epochs to train for.",
+    )
+    return parser
 
-# NOTE: Set up a check-pointer which will load and save checkpoints.
-# Pass the run ID to obtain unique file names for the checkpoints.
-checkpointer = Checkpointer(
-    run.id,
-    model,
-    optimizer,
-    lr_scheduler=lr_scheduler,
-    scaler=scaler,
-    savedir=SAVEDIR,
-    verbose=VERBOSE,
-)
 
-# NOTE: If existing, load model, optimizer, and learning rate scheduler state from
-# latest checkpoint, set random number generator states, and recover the epoch to start
-# training from. Does nothing if there was no checkpoint.
-start_epoch = checkpointer.load_latest_checkpoint()
+def main(args):
+    r"""Train model."""
+    manual_seed(0)  # make deterministic
+    DEV = device("cuda" if cuda.is_available() else "cpu")
 
-# training
-for epoch in range(start_epoch, args.max_epochs):
-    model.train()
-    for step, (inputs, target) in enumerate(train_loader):
-        optimizer.zero_grad()
+    # NOTE: Figure out the `resume` value and pass it to wandb
+    run = wandb.init(resume=get_resume_value(verbose=VERBOSE))
 
-        with autocast(device_type="cuda", dtype=bfloat16):
-            output = model(inputs.to(DEV))
-            loss = loss_func(output, target.to(DEV))
+    # Set up the data, neural net, loss function, and optimizer
+    train_dataset = MNIST("./data", train=True, download=True, transform=ToTensor())
+    train_loader = DataLoader(
+        dataset=train_dataset, batch_size=BATCH_SIZE, shuffle=True
+    )
+    model = Sequential(
+        Conv2d(1, 3, kernel_size=5, stride=2),
+        ReLU(),
+        Flatten(),
+        Linear(432, 50),
+        ReLU(),
+        Linear(50, 10),
+    ).to(DEV)
+    loss_func = CrossEntropyLoss().to(DEV)
+    print(f"Using SGD with learning rate {args.lr}.")
+    optimizer = SGD(model.parameters(), lr=args.lr)
+    lr_scheduler = CosineAnnealingLR(optimizer, T_max=args.max_epochs)
+    scaler = GradScaler()
 
-        if step % LOGGING_INTERVAL == 0:
-            print(f"Epoch {epoch}, Step {step}, Loss {loss.item():.5e}")
-            wandb.log(
-                {
-                    "loss": loss.item(),
-                    "lr": optimizer.param_groups[0]["lr"],
-                    "loss_scale": scaler.get_scale(),
-                    "resumes": checkpointer.num_resumes,
-                }
-            )
+    # NOTE: Set up a check-pointer which will load and save checkpoints.
+    # Pass the run ID to obtain unique file names for the checkpoints.
+    checkpointer = Checkpointer(
+        run.id,
+        model,
+        optimizer,
+        lr_scheduler=lr_scheduler,
+        scaler=scaler,
+        savedir=SAVEDIR,
+        verbose=VERBOSE,
+    )
 
-        scaler.scale(loss).backward()
-        scaler.step(optimizer)  # update neural network parameters
-        scaler.update()  # update the gradient scaler
+    # NOTE: If existing, load model, optimizer, and learning rate scheduler state from
+    # latest checkpoint, set random number generator states, and recover the epoch to
+    # start training from. Does nothing if there was no checkpoint.
+    start_epoch = checkpointer.load_latest_checkpoint()
 
-    lr_scheduler.step()  # update learning rate
+    # training
+    for epoch in range(start_epoch, args.max_epochs):
+        model.train()
+        for step, (inputs, target) in enumerate(train_loader):
+            optimizer.zero_grad()
 
-    # NOTE Put validation code here
-    # eval(model, ...)
+            with autocast(device_type="cuda", dtype=bfloat16):
+                output = model(inputs.to(DEV))
+                loss = loss_func(output, target.to(DEV))
 
-    # NOTE Call checkpointer.step() at the end of the epoch to save a checkpoint.
-    # If SLURM sent us a signal that our time for this job is running out, it will now
-    # also take care of pre-empting the wandb job and requeuing the SLURM job, killing
-    # the current python training script to resume with the requeued job.
-    checkpointer.step()
+            if step % LOGGING_INTERVAL == 0:
+                print(f"Epoch {epoch}, Step {step}, Loss {loss.item():.5e}")
+                wandb.log(
+                    {
+                        "loss": loss.item(),
+                        "lr": optimizer.param_groups[0]["lr"],
+                        "loss_scale": scaler.get_scale(),
+                        "resumes": checkpointer.num_resumes,
+                    }
+                )
 
-wandb.finish()
-# NOTE Remove all created checkpoints once we are done training. If you want to
-# keep the trained model, remove this line.
-checkpointer.remove_checkpoints()
+            scaler.scale(loss).backward()
+            scaler.step(optimizer)  # update neural network parameters
+            scaler.update()  # update the gradient scaler
+
+        lr_scheduler.step()  # update learning rate
+
+        # NOTE Put validation code here
+        # eval(model, ...)
+
+        # NOTE Call checkpointer.step() at the end of the epoch to save a
+        # checkpoint. If SLURM sent us a signal that our time for this job is
+        # running out, it will now also take care of pre-empting the wandb job
+        # and requeuing the SLURM job, killing the current python training script
+        # to resume with the requeued job.
+        checkpointer.step()
+
+    wandb.finish()
+    # NOTE Remove all created checkpoints once we are done training. If you want to
+    # keep the trained model, remove this line.
+    checkpointer.remove_checkpoints()
+
+
+def cli(arg_list=None):
+    r"""Command-line interface for model training."""
+    parser = get_parser()
+    args = parser.parse_args(arg_list)
+    main(args)
+
+
+if __name__ == "__main__":
+    # Run as a script
+    cli()


### PR DESCRIPTION
- Use an ```if __name__ == "__main__":``` block to call the function which defines the main script. There is a separate function to create the parser (this is better practice because it allows calling the main script with arguments that haven't come from the command line, and though not applicable here it plays better with automated argparser documentation generation).
- Make train.py executable (change its file mode, add shebang)
- Move hard-coded parameters (batch_size, logging_interval, checkpoint_dir, verbose) into the argparser.