### PR TITLE
[REF] Improve checkpointing class's name, define preliminary API

### DIFF
--- a/example/launch.sh
+++ b/example/launch.sh
@@ -27,7 +27,7 @@ child="$!"
 function term_handler()
 {
     echo "$(date) ** Job $SLURM_JOB_NAME ($SLURM_JOB_ID) received SIGUSR1 at $(date) **"
-    # The CheckpointHandler will have written the PID of the Python process to a file
+    # The Checkpointer will have written the PID of the Python process to a file
     # so we can send it the SIGUSR1 signal
     PID=$(cat "${SLURM_JOB_ID}.pid")
     echo "$(date) ** Sending kill signal to python process $PID **"

--- a/test/test___init__.py
+++ b/test/test___init__.py
@@ -10,6 +10,7 @@ NAMES = ["world", "github"]
 IDS = NAMES
 
 
+# TODO Remove this function once we have a unit test that uses the checkpointer code
 @pytest.mark.parametrize("name", NAMES, ids=IDS)
 def test_hello(name: str):
     """Test hello function.
@@ -20,6 +21,7 @@ def test_hello(name: str):
     wandb_preempt.hello(name)
 
 
+# TODO Remove this function once we have a unit test that uses the checkpointer code
 @pytest.mark.expensive
 @pytest.mark.parametrize("name", NAMES, ids=IDS)
 def test_hello_expensive(name: str):

--- a/wandb_preempt/__init__.py
+++ b/wandb_preempt/__init__.py
@@ -1,6 +1,14 @@
 """wandb_preempt library."""
 
+from wandb_preempt.checkpointer import Checkpointer, get_resume_value
 
+__all__ = [
+    "Checkpointer",
+    "get_resume_value",
+]
+
+
+# TODO Remove this function once we have a unit test that uses the checkpointer code
 def hello(name):
     """Say hello to a name.
 

--- a/wandb_preempt/checkpointer.py
+++ b/wandb_preempt/checkpointer.py
@@ -55,16 +55,16 @@ def get_resume_value(verbose: bool = False) -> str:
     return resume
 
 
-class CheckpointHandler:
+class Checkpointer:
     """Class for storing, loading, and removing checkpoints.
 
     Can be marked as pre-empted by sending a `SIGUSR1` signal to a Python session.
 
     How to use this class:
 
-    - Create an instance in your training loop, `handler = CheckpointHandler(...)`.
-    - At the end of each epoch, call `handler.step()` to save a checkpoint.
-      If the job received the `SIGUSR1` signal, the handler will requeue the at
+    - Create an instance in your training loop, `checkpointer = Checkpointer(...)`.
+    - At the end of each epoch, call `checkpointer.step()` to save a checkpoint.
+      If the job received the `SIGUSR1` signal, the checkpointer will requeue the at
       the end of its checkpointing step.
     """
 
@@ -79,7 +79,7 @@ class CheckpointHandler:
         savedir: str = "checkpoints",
         verbose: bool = False,
     ) -> None:
-        """Set up a checkpoint handler.
+        """Set up a checkpointer.
 
         Args:
             run_id: A unique identifier for this run.


### PR DESCRIPTION
Renames `CheckpointHandler` into `Checkpointer`.
It's shorter and less prone to being confused with other 'handler's (e.g. signal handlers).
