### PR TITLE
[DOC] Set up `mkdocs` to for generating documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Summary
+# wandb_preempt
 
 This repository contains a tutorial on how to combine `wandb` sweeps with
 Slurm's pre-emption, i.e. how to automatically re-queue and resume runs from a
@@ -8,8 +8,6 @@ This is work in progress:
 
 - TODO Debug failure scenarios
 
-- TODO Freeze interface
-
 - TODO Write a self-contained walk-through.
 
 ## Installation
@@ -17,49 +15,3 @@ This is work in progress:
 ```bash
 pip install git+https://github.com/f-dangel/wandb_preempt.git@main
 ```
-
-# Developer guide
-
-This guide describes principles and workflows for developers.
-
-## Setup
-
-We recommend programming in a fresh virtual environment. You can set up the
-`conda` environment and activate it
-
-```bash
-make conda-env
-conda activate wandb_preempt
-```
-
-If you don't use `conda`, set up your preferred environment and run
-
-```bash
-pip install -e ."[lint,test]"
-```
-to install the package in editable mode, along with all required development dependencies
-(the quotes are for OS compatibility, see
-[here](https://github.com/mu-editor/mu/issues/852#issuecomment-498759372)).
-
-## Continuous integration
-
-To standardize code style and enforce high quality, checks are carried out with
-Github actions when you push. You can also run them locally, as they are managed
-via `make`:
-
-- Run tests with `make test`
-
-- Run all linters with `make lint`, or separately with:
-
-    - Run auto-formatting and import sorting with `make black` and `make isort`
-
-    - Run linting with `make flake8`
-
-    - Run docstring checks with `make pydocstyle-check` and `make darglint-check`
-
-## Documentation
-
-We use the [Google docstring
-convention](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
-and `mkdocs` which allows using markdown syntax in a docstring to achieve
-formatting.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,8 @@
+::: wandb_preempt.get_resume_value
+
+::: wandb_preempt.Checkpointer
+    options:
+        members:
+            - __init__
+            - load_latest_checkpoint
+            - step

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,0 +1,45 @@
+# Developer guide
+
+This guide describes principles and workflows for developers.
+
+## Setup
+
+We recommend programming in a fresh virtual environment. You can set up the
+`conda` environment and activate it
+
+```bash
+make conda-env
+conda activate wandb_preempt
+```
+
+If you don't use `conda`, set up your preferred environment and run
+
+```bash
+pip install -e ."[lint,test]"
+```
+to install the package in editable mode, along with all required development dependencies
+(the quotes are for OS compatibility, see
+[here](https://github.com/mu-editor/mu/issues/852#issuecomment-498759372)).
+
+## Continuous integration
+
+To standardize code style and enforce high quality, checks are carried out with
+Github actions when you push. You can also run them locally, as they are managed
+via `make`:
+
+- Run tests with `make test`
+
+- Run all linters with `make lint`, or separately with:
+
+    - Run auto-formatting and import sorting with `make black` and `make isort`
+
+    - Run linting with `make flake8`
+
+    - Run docstring checks with `make pydocstyle-check` and `make darglint-check`
+
+## Documentation
+
+We use the [Google docstring
+convention](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
+and `mkdocs` which allows using markdown syntax in a docstring to achieve
+formatting. To build the docs, run `mkdocs serve` in the repository root.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/example/launch.sh
+++ b/example/launch.sh
@@ -27,7 +27,7 @@ child="$!"
 function term_handler()
 {
     echo "$(date) ** Job $SLURM_JOB_NAME ($SLURM_JOB_ID) received SIGUSR1 at $(date) **"
-    # The CheckpointHandler will have written the PID of the Python process to a file
+    # The Checkpointer will have written the PID of the Python process to a file
     # so we can send it the SIGUSR1 signal
     PID=$(cat "${SLURM_JOB_ID}.pid")
     echo "$(date) ** Sending kill signal to python process $PID **"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,45 @@
+site_name: wandb_preempt
+site_url: https://https://readthedocs.org/projects/wandb_preempt/
+repo_url: https://github.com/f-dangel/wandb_preempt/
+repo_name: f-dangel/wandb_preempt
+site_author: Felix Dangel, Scott Lowe
+watch:
+  - wandb_preempt
+nav:
+    - Getting Started: index.md
+    - API Documentation: api.md
+    - Developer Notes: develop.md
+theme:
+    name: material
+    features:
+        - content.code.copy
+copyright: Copyright &copy; 2024 Felix Dangel, Scott Lowe
+markdown_extensions:
+    - pymdownx.arithmatex: # LaTeX math
+          generic: true
+    - pymdownx.highlight: # code highlighting
+          anchor_linenums: true
+          line_spans: __span
+          pygments_lang_class: true
+    - pymdownx.inlinehilite # code highlighting
+    - pymdownx.snippets # code highlighting
+    - pymdownx.superfences # code highlighting
+    - footnotes
+plugins:
+    - mkdocstrings:
+        default_handler: python
+        handlers:
+            python:
+                options:
+                      show_root_heading: true
+                      show_source: true
+                      show_bases: true
+                      show_signature_annotations: true
+                      separate_signature: true
+                      docstring_section_style: list
+                      merge_init_into_class: true
+    - search
+extra_javascript:
+    - javascripts/mathjax.js # LaTeX math
+    - https://polyfill.io/v3/polyfill.min.js?features=es6 # LaTeX math
+    - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js # LaTeX math

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,14 @@ example = [
     "torchvision",
 ]
 
+# Dependencies needed to generate the documentation (comma/line-separated), uses
+# pinned versions to avoid future breakdowns
+doc = [
+    "mkdocs==1.4.3",
+    "mkdocs-material==9.1.17",
+    "mkdocstrings[python]==0.22.0",
+]
+
 [tool.setuptools_scm]
 
 [tool.isort]

--- a/test/test___init__.py
+++ b/test/test___init__.py
@@ -10,6 +10,7 @@ NAMES = ["world", "github"]
 IDS = NAMES
 
 
+# TODO Remove this function once we have a unit test that uses the checkpointer code
 @pytest.mark.parametrize("name", NAMES, ids=IDS)
 def test_hello(name: str):
     """Test hello function.
@@ -20,6 +21,7 @@ def test_hello(name: str):
     wandb_preempt.hello(name)
 
 
+# TODO Remove this function once we have a unit test that uses the checkpointer code
 @pytest.mark.expensive
 @pytest.mark.parametrize("name", NAMES, ids=IDS)
 def test_hello_expensive(name: str):

--- a/wandb_preempt/__init__.py
+++ b/wandb_preempt/__init__.py
@@ -1,6 +1,14 @@
 """wandb_preempt library."""
 
+from wandb_preempt.checkpointer import Checkpointer, get_resume_value
 
+__all__ = [
+    "Checkpointer",
+    "get_resume_value",
+]
+
+
+# TODO Remove this function once we have a unit test that uses the checkpointer code
 def hello(name):
     """Say hello to a name.
 

--- a/wandb_preempt/checkpointer.py
+++ b/wandb_preempt/checkpointer.py
@@ -13,6 +13,8 @@ from typing import Dict, List, Optional, Set, Union
 import wandb
 from torch import cuda, device, get_rng_state, load, save, set_rng_state
 from torch.cuda.amp import GradScaler
+from torch.nn import Module
+from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
 from wandb import Api
 
@@ -71,8 +73,8 @@ class Checkpointer:
     def __init__(
         self,
         run_id: str,
-        model,
-        optimizer,
+        model: Module,
+        optimizer: Optimizer,
         lr_scheduler: Optional[LRScheduler] = None,
         scaler: Optional[GradScaler] = None,
         metadata: Optional[Dict] = None,

--- a/wandb_preempt/checkpointer.py
+++ b/wandb_preempt/checkpointer.py
@@ -55,16 +55,16 @@ def get_resume_value(verbose: bool = False) -> str:
     return resume
 
 
-class CheckpointHandler:
+class Checkpointer:
     """Class for storing, loading, and removing checkpoints.
 
     Can be marked as pre-empted by sending a `SIGUSR1` signal to a Python session.
 
     How to use this class:
 
-    - Create an instance in your training loop, `handler = CheckpointHandler(...)`.
-    - At the end of each epoch, call `handler.step()` to save a checkpoint.
-      If the job received the `SIGUSR1` signal, the handler will requeue the at
+    - Create an instance in your training loop, `checkpointer = Checkpointer(...)`.
+    - At the end of each epoch, call `checkpointer.step()` to save a checkpoint.
+      If the job received the `SIGUSR1` signal, the checkpointer will requeue the at
       the end of its checkpointing step.
     """
 
@@ -79,7 +79,7 @@ class CheckpointHandler:
         savedir: str = "checkpoints",
         verbose: bool = False,
     ) -> None:
-        """Set up a checkpoint handler.
+        """Set up a checkpointer.
 
         Args:
             run_id: A unique identifier for this run.


### PR DESCRIPTION
Review only after #3.

Sets up a minimal scaffold for generating documentation with `mkdocs` by running `mkdocs serve` in the repository root.
I will add RTD integration in a separate PR.