### PR TITLE
[REF] Change epochs to be indexed from 1

### DIFF
--- a/example/train.py
+++ b/example/train.py
@@ -82,10 +82,10 @@ def main(args):
     # NOTE: If existing, load model, optimizer, and learning rate scheduler state from
     # latest checkpoint, set random number generator states, and recover the epoch to
     # start training from. Does nothing if there was no checkpoint.
-    start_epoch = checkpointer.load_latest_checkpoint()
+    last_epoch = checkpointer.load_latest_checkpoint()
 
     # training
-    for epoch in range(start_epoch, args.epochs):
+    for epoch in range(last_epoch + 1, args.epochs + 1):
         model.train()
         for step, (inputs, target) in enumerate(train_loader):
             optimizer.zero_grad()

--- a/wandb_preempt/checkpointer.py
+++ b/wandb_preempt/checkpointer.py
@@ -183,8 +183,9 @@ class Checkpointer:
         passed at initialization.
 
         Returns:
-            The epoch number at which training should resume, and the extra information
-            that was passed by the user as a dictionary to the :meth:`step` function.
+            step (int): The number of times the checkpoint handler has been stepped.
+            extra_info (dict): extra information that was passed by the user as a
+                dictionary to the :meth:`step` function.
         """
         loadpath = self.latest_checkpoint()
         if loadpath is None:
@@ -215,7 +216,7 @@ class Checkpointer:
             else:
                 set_rng_state(rng_state)
 
-        return data["checkpoint_step"] + 1, data["extra_info"]
+        return data["checkpoint_step"], data["extra_info"]
 
     def remove_checkpoints(self, keep_latest: bool = False):
         """Remove checkpoints.
@@ -332,6 +333,9 @@ class Checkpointer:
                 dictionary is returned when loading the latest checkpoint with
                 :meth:`load_latest_checkpoint`. Default: `None` (empty dictionary).
         """
+        # Increase the number of steps taken
+        self.step_count += 1
+        # Save the checkpoint
         self.save_checkpoint({} if extra_info is None else extra_info)
         # Remove stale checkpoints
         self.remove_checkpoints(keep_latest=True)
@@ -343,5 +347,3 @@ class Checkpointer:
             self.maybe_requeue_slurm_job()
             self.maybe_print("Exiting with error code 1.")
             exit(1)
-        # Increase the number of steps taken
-        self.step_count += 1


### PR DESCRIPTION
It doesn't make much sense for the loader to return one more than the number of checkpointing steps taken, so now the loader returns the number of checkpointing steps instead. This necessitates indexing epochs from 1 to distinguish between no epochs performed (no file loaded), which returns 0 and 1 epoch performed (returns 1). IMO this change is desirable anyway because thinking about epochs in this way means it is natural for 0.5 to be halfway through the first epoch, and 0 to be the initial model before any training.