### PR TITLE
[ENH] Mark wandb run as preempting as soon as signal received

### DIFF
--- a/wandb_preempt/checkpointer.py
+++ b/wandb_preempt/checkpointer.py
@@ -115,11 +115,15 @@ class Checkpointer:
             sig: The signal number.
             frame: The current stack frame.
         """
+        if self.marked_preempted:
+            self.maybe_print(f"Received signal {sig}, but already preempting.")
+            return
+        self.marked_preempted = True
         self.maybe_print(
-            f"Received signal {sig}. Marking as pre-empted and will halt and requeue"
+            f"Received signal {sig}. Marking as preempting and will halt and requeue"
             " the job at next call of checkpointer.step()."
         )
-        self.marked_preempted = True
+        wandb.mark_preempting()
 
     def checkpoint_path(self, counter: int) -> str:
         """Get the path to a checkpoint file for a given checkpointing step.


### PR DESCRIPTION
Mark the job as preempting on wandb as soon as the interruption signal is received, so if the job suddenly dies wandb will report it as preempting/preempted and not crashed/failed. This ensures it is clear when reading wandb which jobs have stopped because they were preempted and which died of their own accord. This doesn't make much impact in the setting where we reach the time limit of the job and requeue it due to SIGUSR1, but will make more of an impact when the job is interrupted without much preemption warning due to queue priority.

Note that we somewhat redundantly still call `wandb.mark_preempting()` later in the code in `Checkpointer.preempt_wandb_run`. This is just to make sure the job is definitely marked correctly on wandb even if the two methods are called in quick succession.