### PR TITLE
[ADD] Allow for immediate pre-emption with correct wandb log rewinding

### DIFF
--- a/example/launch.sh
+++ b/example/launch.sh
@@ -8,8 +8,8 @@
 #SBATCH --qos=m5
 #SBATCH --open-mode=append
 #SBATCH --time=00:04:00
-#SBATCH --array=0-9
-#SBATCH --signal=B:SIGUSR1@120  # Send signal SIGUSR1 120 seconds before the job hits the time limit
+#SBATCH --array=0
+#SBATCH --signal=B:SIGUSR1@150  # Send signal SIGUSR1 120 seconds before the job hits the time limit
 
 echo "Job $SLURM_JOB_NAME ($SLURM_JOB_ID) begins on $(hostname), submitted from $SLURM_SUBMIT_HOST ($SLURM_CLUSTER_NAME)"
 echo ""
@@ -20,7 +20,7 @@ if [ "$SLURM_ARRAY_TASK_COUNT" != "" ]; then
 fi
 
 # NOTE that we need to use srun here, otherwise the Python process won't receive the SIGUSR1 signal
-srun wandb agent --count=1 f-dangel-team/example-preemptable-sweep/4m89qo6r &
+srun --unbuffered wandb agent --count=1 f-dangel-team/example-preemptable-sweep/4m89qo6r &
 child="$!"
 
 # Set up a handler to pass the SIGUSR1 to the python session launched by the agent

--- a/example/train.py
+++ b/example/train.py
@@ -86,21 +86,21 @@ def main(args):
     start_epoch = 0 if checkpoint_index is None else checkpoint_index + 1
 
     # NOTE forking must be enabled by the wandb team for your project.
-    # wandb_resume_step = extra_info.get("wandb_step", None)
-    # resume_from = (
-    #    None if wandb_resume_step is None else f"{run_id}?_step={wandb_resume_step}"
-    # )
-    # resume = "allow" if resume_from is None else None
-    # print("resume_from:", resume_from)
-    # print("resume:", resume)
-    # wandb.init(resume=resume, resume_from=resume_from)
+    wandb_resume_step = extra_info.get("wandb_step", None)
+    resume_from = (
+        None if wandb_resume_step is None else f"{run_id}?_step={wandb_resume_step}"
+    )
+    resume = "allow" if resume_from is None else None
+    print("resume_from:", resume_from)
+    print("resume:", resume)
+    wandb.init(resume=resume, resume_from=resume_from)
 
     # NOTE: Allow runs to resume by passing 'allow' to wandb
-    wandb.init(resume="allow")
-    print("Wandb step before manually setting it:", wandb.run.step)
+    # wandb.init(resume="allow")
+    # print("Wandb step before manually setting it:", wandb.run.step)
     # NOTE: Currently getting an error from setattr here
-    wandb.run.step = extra_info.get("wandb_step", 0)
-    print("Wandb step after manually setting it:", wandb.run.step)
+    # wandb.run.step = extra_info.get("wandb_step", 0)
+    # print("Wandb step after manually setting it:", wandb.run.step)
 
     # training
     for epoch in range(start_epoch, args.epochs):

--- a/example/train.py
+++ b/example/train.py
@@ -85,14 +85,22 @@ def main(args):
     # Select the remaining epochs to train
     start_epoch = 0 if checkpoint_index is None else checkpoint_index + 1
 
-    wandb_resume_step = extra_info.get("wandb_step", None)
-    resume_from = (
-        None if wandb_resume_step is None else f"{run_id}?_step={wandb_resume_step}"
-    )
-    print("Resume string:", resume_from)
+    # NOTE forking must be enabled by the wandb team for your project.
+    # wandb_resume_step = extra_info.get("wandb_step", None)
+    # resume_from = (
+    #    None if wandb_resume_step is None else f"{run_id}?_step={wandb_resume_step}"
+    # )
+    # resume = "allow" if resume_from is None else None
+    # print("resume_from:", resume_from)
+    # print("resume:", resume)
+    # wandb.init(resume=resume, resume_from=resume_from)
 
     # NOTE: Allow runs to resume by passing 'allow' to wandb
-    wandb.init(resume="allow", resume_from=resume_from)
+    wandb.init(resume="allow")
+    print("Wandb step before manually setting it:", wandb.run.step)
+    # NOTE: Currently getting an error from setattr here
+    wandb.run.step = extra_info.get("wandb_step", 0)
+    print("Wandb step after manually setting it:", wandb.run.step)
 
     # training
     for epoch in range(start_epoch, args.epochs):


### PR DESCRIPTION
This PR aims to address #16 and is a DRAFT to discuss problems.

The goal is to allow the `Checkpointer` to pre-empt immediately when receiving a signal, without writing a new checkpoint (because we may not have enough grace time). This means there can be duplicate runs if `wandb.log` was called between the last call of `.step` and the signal reception.

- [X] As a first step to achieve this, we should store `wand.run.step` inside a checkpoint. We can then restore that step when loading the latest checkpoint. This PR currently does this using the `extra_info` option, and I think we can discuss better ways once everything is working.
- [ ] Next, we need to make sure that we correctly rewind the logs. There are two ways, both of which currently fail
  1. Specifying `resume_from=<run_id>?_step=<step>` in `wandb.init`. This does not work out of the box and one must request this feature to be enabled from the `wandb` support, see [here](https://docs.wandb.ai/guides/runs/rewind).
  2. Setting `wandb.run.step` manually. This fails with an `AttributeError: can't set attribute`
  3. Are there other ways, like manually deleting logs?
 - [ ] Last, we need to add a flag to the `Checkpointer` which, if enabled, will make it pre-empt and requeue immediately when receiving a signal.

@scottclowe do let me know if you have other ideas how to achieve this and feel free to push to this branch for experimentation.
